### PR TITLE
Bugfix 150 impute

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rSOILWAT2
-Version: 3.1.4
-Date: 2019-10-25
+Version: 3.1.5
+Date: 2019-10-29
 Title: An Ecohydrological Ecosystem-Scale Water Balance Simulation Model
 Description: Access to the C-based SOILWAT2 v5.4.0 and functionality for
   SQLite-database of weather data.

--- a/man/dbW_estimate_WGen_coefs.Rd
+++ b/man/dbW_estimate_WGen_coefs.Rd
@@ -4,9 +4,9 @@
 \alias{dbW_estimate_WGen_coefs}
 \title{Estimate coefficients for use by \var{SOILWAT2} weather generator}
 \usage{
-dbW_estimate_WGen_coefs(weatherData, WET_limit_cm = 0, na.rm = FALSE,
-  valNA = NULL, imputation_type = c("none", "mean", "locf"),
-  imputation_span = 5L)
+dbW_estimate_WGen_coefs(weatherData, WET_limit_cm = 0,
+  propagate_NAs = FALSE, valNA = NULL, imputation_type = c("none",
+  "mean", "locf"), imputation_span = 5L)
 }
 \arguments{
 \item{weatherData}{A list of elements of class
@@ -18,9 +18,9 @@ this value is considered \var{wet} instead of \var{dry}. Default is 0.
 This values should be equal to the corresponding value used in
 \var{SOILWAT2}'s function \code{SW_MKV_today}.}
 
-\item{na.rm}{A logical value. If \code{TRUE}, then missing weather values
-in the input \code{weatherData} are excluded; if \code{FALSE}, then
-missing values are propagated.}
+\item{propagate_NAs}{A logical value. If \code{TRUE}, then missing weather
+values in the input \code{weatherData} are excluded; if \code{FALSE}, then
+missing values are propagated to the estimation. See Details.}
 
 \item{valNA}{The (numerical) value of missing weather data.
 If \code{NULL}, then default values are interpreted as missing.}
@@ -96,6 +96,23 @@ Markov weather generator in \var{SOILWAT2} \var{> v4.2.5}.
   imputation approaches in order to fill in those failed coefficient
   estimates; see \code{\link{impute_df}}, but please note that any such
   imputation likely introduces biases in the generated weather.
+}
+
+\section{Details}{
+ Most users will likely want to set \code{propagate_NAs} to
+  \code{FALSE}. Note: \code{propagate_NAs} corresponds to \code{!na.rm}
+  from previous versions of this function with a different default value.
+  Consider an example: a the 30-year long input \code{weatherData} is
+  complete except for missing values on Jan 1, 2018.
+  \itemize{
+    \item If \code{propagate_NAs} is set to \code{TRUE}, then the
+    coefficients for day 1 and week 1 of year will be \code{NA} --
+    despite all the available data. In this case, the missing coefficients
+    for day 1 and week 1 of year will be imputed.
+  \item If \code{propagate_NAs} is set to \code{FALSE}, then the coefficients
+    for day 1 and week 1 of year will be calculated based on the non-missing
+    values for that day respectively that week of year. No imputation occurs.
+  }
 }
 
 \examples{

--- a/man/dbW_generateWeather.Rd
+++ b/man/dbW_generateWeather.Rd
@@ -5,8 +5,7 @@
 \title{Generate daily weather data using SOILWAT2's weather generator}
 \usage{
 dbW_generateWeather(weatherData, years = NULL, wgen_coeffs = NULL,
-  na.rm = FALSE, imputation_type = "mean", imputation_span = 5L,
-  seed = NULL)
+  imputation_type = "mean", imputation_span = 5L, seed = NULL)
 }
 \arguments{
 \item{weatherData}{A list of elements of class
@@ -20,10 +19,6 @@ daily weather. If \code{NULL}, then extracted from \code{weatherData}.}
 \var{mkv_woy}, i.e., the return value of
 \code{\link{dbW_estimate_WGen_coefs}}. If \code{NULL}, then determined
 based on \code{weatherData}.}
-
-\item{na.rm}{A logical value. If \code{TRUE}, then missing weather values
-in the input \code{weatherData} are excluded; if \code{FALSE}, then
-missing values are propagated.}
 
 \item{imputation_type}{A character string describing the imputation method;
  currently, one of three values: \describe{

--- a/man/impute_df.Rd
+++ b/man/impute_df.Rd
@@ -2,13 +2,14 @@
 % Please edit documentation in R/swWeatherGenerator.R
 \name{impute_df}
 \alias{impute_df}
-\title{Imputes missing values in a data.frame}
+\title{Imputes missing values in a \code{data.frame}}
 \usage{
 impute_df(x, imputation_type = c("none", "mean", "locf"),
-  imputation_span = 5L)
+  imputation_span = 5L, cyclic = FALSE)
 }
 \arguments{
-\item{x}{A \code{\link{data.frame}} with numerical columns.}
+\item{x}{A \code{\link{data.frame}} with numerical columns. Imputation
+works on each column separately.}
 
 \item{imputation_type}{A character string describing the imputation method;
  currently, one of three values: \describe{
@@ -24,10 +25,14 @@ impute_df(x, imputation_type = c("none", "mean", "locf"),
 
 \item{imputation_span}{An integer value. The number of non-missing values
 considered if \code{imputation_type = "mean"}.}
+
+\item{cyclic}{A logical value. If \code{TRUE}, then the last row of \code{x}
+is considered to be a direct neighbor of the first row, e.g., rows of
+\code{x} represent day of year for an average year.}
 }
 \value{
 An updated version of \code{x}.
 }
 \description{
-Imputes missing values in a data.frame
+Imputes missing values in a \code{data.frame}
 }

--- a/tests/testthat/test_WeatherGenerator_functionality.R
+++ b/tests/testthat/test_WeatherGenerator_functionality.R
@@ -26,10 +26,12 @@ test_that("Weather generator: estimate input parameters", {
     test_df <- data.frame(dbW_weatherData_to_dataframe(test_dat, valNA = NULL))
 
     if (anyNA(test_df)) {
-      expect_warning(res <- dbW_estimate_WGen_coefs(test_df),
+      expect_warning(res <- dbW_estimate_WGen_coefs(test_df,
+        propagate_NAs = TRUE),
         "Insufficient weather data to estimate values")
 
-      expect_message(res <- dbW_estimate_WGen_coefs(test_df, na.rm = TRUE,
+      expect_message(res <- dbW_estimate_WGen_coefs(test_df,
+        propagate_NAs = FALSE,
         imputation_type = "mean"),
         "Impute missing")
 
@@ -60,14 +62,12 @@ test_that("Weather generator: generate weather", {
 
     # Case 1: generate weather for dataset and impute missing values
     wout[[1]] <- dbW_generateWeather(test_dat,
-      na.rm = TRUE,
       imputation_type = "mean",
       imputation_span = 5)
 
     # Case 2: generate weather based on partial dataset,
     #   use estimated weather generator coefficients from full dataset
     wgen_coeffs <- dbW_estimate_WGen_coefs(test_dat,
-      na.rm = TRUE,
       imputation_type = "mean",
       imputation_span = 5)
     wout[[2]] <- dbW_generateWeather(test_dat[(n - 5):n],

--- a/tests/testthat/test_imputation.R
+++ b/tests/testthat/test_imputation.R
@@ -1,0 +1,91 @@
+context("Imputation")
+
+Nrows <- 30
+Nmiss <- 5
+
+df <- data.frame(
+  linear = seq_len(Nrows),
+  all_missing = NA,
+  all_same = 1,
+  cyclic = cos(2 * pi * seq_len(Nrows) / Nrows)
+)
+
+vars <- colnames(df)
+vars_with_values <- vars[!apply(df, 2, anyNA)]
+
+types <- c("mean", "locf")
+cyclicity <- c(FALSE, TRUE)
+
+#---TESTS
+test_that("Impute missing values", {
+  #-------
+  # Check 1: If every value is missing, then no numeric values are imputed.
+  # Check 2: If missing values remain, then a warning is issued.
+  # Check 3: If no value is missing, then no value is modified.
+  df1 <- df
+
+  for (type in types) {
+    res1 <- expect_warning(impute_df(
+      x = df1,
+      imputation_type = type
+    ))
+    expect_identical(df1, res1)
+  }
+
+  #------- Last values are missing
+  df2 <- df[, vars_with_values]
+  idsNA <- (Nrows - Nmiss):Nrows
+  df2[idsNA, ] <- NA
+
+  for (type in types) {
+    res2 <- expect_silent(impute_df(
+      x = df2,
+      imputation_type = type,
+      cyclic = FALSE
+    ))
+
+    for (v in vars_with_values) {
+      expect_true(!anyNA(res2[, v]))
+      if (type == "locf") {
+        expect_true(all(res2[idsNA, v] == df2[idsNA[1] - 1, v]))
+      }
+    }
+  }
+
+  #------- First values are missing
+  df3 <- df[, vars_with_values]
+  idsNA <- 1:Nmiss
+  df3[idsNA, ] <- NA
+
+  for (type in types) for (cyclic in cyclicity) {
+    if (type == "locf" && !cyclic) {
+      res3 <- expect_warning(impute_df(
+        x = df3,
+        imputation_type = type,
+        cyclic = cyclic
+      ))
+    } else {
+      res3 <- expect_silent(impute_df(
+        x = df3,
+        imputation_type = type,
+        cyclic = cyclic
+      ))
+    }
+
+    for (v in vars_with_values) {
+      if (type == "locf") {
+        if (cyclic) {
+          # last value is imputed
+          expect_true(all(res3[idsNA, v] == df3[Nrows, v]))
+        } else {
+          # no value to can be imputed --> NAs
+          expect_true(all(is.na(res3[idsNA, v])))
+        }
+
+      } else if (type == "mean") {
+        expect_true(!anyNA(res3[, v]))
+      }
+    }
+  }
+
+})


### PR DESCRIPTION
- fix cyclic behavior of `impute_df`
- improve the documentation of the differences in the treatment of NAs in weather data versus NAs in weather generator coefficients (change argument from `na.rm` to `propagate_NAs` and switch default behavior)