### PR TITLE
fix CF on dry days in dbW_estimate_WGen_coefs()

### DIFF
--- a/R/swWeatherGenerator.R
+++ b/R/swWeatherGenerator.R
@@ -295,7 +295,8 @@ dbW_estimate_WGen_coefs <- function(weatherData, WET_limit_cm = 0,
       iswet <- if (na.rm) {
           which_wet <- which(x[, "WET"]) # numeric vector
           out <- rep(FALSE, length(x[, "WET"]))
-          out[which_wet] <- TRUE # only days where 'WET' is TRUE are considered wet
+          # only days where 'WET' is TRUE are considered wet
+          out[which_wet] <- TRUE
           out # logical vector same length as x[, "WET"]
         } else {
           x[, "WET"] # logical vector

--- a/R/swWeatherGenerator.R
+++ b/R/swWeatherGenerator.R
@@ -303,7 +303,7 @@ dbW_estimate_WGen_coefs <- function(weatherData, WET_limit_cm = 0,
       isanywet <- isTRUE(any(iswet, na.rm = na.rm))
       # previously isdry became all FALSE if na.rm = TRUE (because then iswet
       # was numeric  vector with all positive digits)
-      isdry <- !iswet 
+      isdry <- !iswet
       isanydry <- isTRUE(any(isdry, na.rm = na.rm))
 
       # if no wet/dry days in week of year, then use overall mean instead

--- a/R/swWeatherGenerator.R
+++ b/R/swWeatherGenerator.R
@@ -292,9 +292,18 @@ dbW_estimate_WGen_coefs <- function(weatherData, WET_limit_cm = 0,
     function(x) {
       # if `na.rm` is TRUE, then consider `WET` = NA as FALSE
       # if `na.rm` is FALSE, then propagate NAs in `WET` -> neither wet nor dry
-      iswet <- if (na.rm) which(x[, "WET"]) else x[, "WET"]
+      iswet <- if (na.rm) {
+          which_wet <- which(x[, "WET"]) # numeric vector
+          out <- rep(FALSE, length(iswet))
+          out[which_wet] <- TRUE # only days where 'WET' is TRUE are considered wet
+          out # logical vector same length as x[, "WET"]
+        } else {
+          x[, "WET"] # logical vector
+        }
       isanywet <- isTRUE(any(iswet, na.rm = na.rm))
-      isdry <- !iswet
+      # previously isdry became all FALSE if na.rm = TRUE (because then iswet
+      # was numeric  vector with all positive digits)
+      isdry <- !iswet 
       isanydry <- isTRUE(any(isdry, na.rm = na.rm))
 
       # if no wet/dry days in week of year, then use overall mean instead

--- a/R/swWeatherGenerator.R
+++ b/R/swWeatherGenerator.R
@@ -294,7 +294,7 @@ dbW_estimate_WGen_coefs <- function(weatherData, WET_limit_cm = 0,
       # if `na.rm` is FALSE, then propagate NAs in `WET` -> neither wet nor dry
       iswet <- if (na.rm) {
           which_wet <- which(x[, "WET"]) # numeric vector
-          out <- rep(FALSE, length(iswet))
+          out <- rep(FALSE, length(x[, "WET"]))
           out[which_wet] <- TRUE # only days where 'WET' is TRUE are considered wet
           out # logical vector same length as x[, "WET"]
         } else {


### PR DESCRIPTION
In  `dbW_estimate_WGen_coefs()` when `propagate_NAs = FALSE`, then Tmax_mean_dry and Tmin_mean_dry are calculated as 
mean temperature on all days (not just dry days). As a result the corrections factors CF_Tmax_dry and CF_Tmin_dry are 0 when  `propagate_NAs = FALSE`. The following code illustrates the issue:

`wdata <- data.frame(dbW_weatherData_to_dataframe(rSOILWAT2::weatherData))`

Correction factors incorrect (CF is 0 for dry days)
`res2 <- dbW_estimate_WGen_coefs(wdata, propagate_NAs = FALSE) # default`
`head(res2[[1]]) `

Correction factors correct

`res2 <- dbW_estimate_WGen_coefs(wdata, propagate_NAs = TRUE)`
`head(res2[[1]])`

The fix I propose here is making `iswet` a logical vector when `na.rm = TRUE`, so that `isdry` is correctly computed. 