### PR TITLE
Prepare development for v6.0.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "src/SOILWAT2"]
 	path = src/SOILWAT2
 	url = https://github.com/DrylandEcology/SOILWAT2
-	branch = release/devel_v7.1.0
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "src/SOILWAT2"]
 	path = src/SOILWAT2
 	url = https://github.com/DrylandEcology/SOILWAT2
-	branch = master
+	branch = release/devel_v7.1.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rSOILWAT2
-Version: 6.0.2-9000
+Version: 6.0.2
 Title: An Ecohydrological Ecosystem-Scale Water Balance Simulation Model
-Description: Access to the C-based SOILWAT2 v7.0.0 and functionality for
+Description: Access to the C-based SOILWAT2 v7.1.0 and functionality for
   SQLite-database of weather data.
 Authors@R: c(
   person(

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rSOILWAT2
-Version: 6.0.1
+Version: 6.0.2-9000
 Title: An Ecohydrological Ecosystem-Scale Water Balance Simulation Model
 Description: Access to the C-based SOILWAT2 v7.0.0 and functionality for
   SQLite-database of weather data.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# rSOILWAT2 v6.0.2-9000
+
+
 # rSOILWAT2 v6.0.1
 
 ## Bugfix

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # rSOILWAT2 v6.0.2-9000
-
+* This version produces the same output as the previous version.
+* Update `SOILWAT2` to v7.1.0 which prepares for thread-safety and reentrancy
+* C-side of `rSOILWAT2` gains new globals of the four main abstract types in
+  `SOILWAT2` - SW_ALL, SW_OUTPUT_POINTERS, LOG_INFO, and PATH_INFO -
+  to interact with `SOILWAT2`.
 
 # rSOILWAT2 v6.0.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# rSOILWAT2 v6.0.2-9000
+# rSOILWAT2 v6.0.2
 * This version produces the same output as the previous version.
 * Update `SOILWAT2` to v7.1.0 which prepares for thread-safety and reentrancy
 * C-side of `rSOILWAT2` gains new globals of the four main abstract types in

--- a/R/Rsw.R
+++ b/R/Rsw.R
@@ -311,6 +311,7 @@ sw_exec <- function(
 
   # Run SOILWAT2
   res <- .Call(C_start, input, inputData, weatherList, quiet)
+
   slot(res, "version") <- rSW2_version()
   slot(res, "timestamp") <- rSW2_timestamp()
 
@@ -383,6 +384,7 @@ sw_inputDataFromFiles <- function(
   input <- sw_args(dir, files.in, echo = FALSE, quiet = quiet)
 
   res <- .Call(C_onGetInputDataFromFiles, input, quiet)
+
   slot(res, "version") <- rSW2_version()
   slot(res, "timestamp") <- rSW2_timestamp()
 
@@ -402,6 +404,7 @@ sw_outputData <- function(inputData) {
   on.exit(setwd(dir_prev), add = TRUE)
 
   res <- .Call(C_onGetOutput, inputData)
+
   slot(res, "version") <- rSW2_version()
   slot(res, "timestamp") <- rSW2_timestamp()
 

--- a/R/swWeatherGenerator.R
+++ b/R/swWeatherGenerator.R
@@ -1155,8 +1155,7 @@ dbW_generateWeather <- function(
 
   #--- Process weather in SOILWAT2
   set.seed(seed)
-  dbW_weatherData_round(
-    .Call(C_rSW2_processAllWeather, weatherData, sw_in),
-    digits = digits
-  )
+  res <- .Call(C_rSW2_processAllWeather, weatherData, sw_in)
+
+  dbW_weatherData_round(res, digits = digits)
 }

--- a/inst/extdata/example1/Input/outsetup.in
+++ b/inst/extdata/example1/Input/outsetup.in
@@ -40,7 +40,6 @@
 # in any order. For example: 'TIMESTEP mo wk' will output for month and week
 #
 
-OUTSEP c
 TIMESTEP dy wk mo yr # must be lowercase
 
 #         KEY     SUMTYPE   PERIOD   START END FILENAME_PREFIX      DESCRIPTION

--- a/src/SW_R_lib.c
+++ b/src/SW_R_lib.c
@@ -383,7 +383,7 @@ SEXP start(SEXP inputOptions, SEXP inputData, SEXP weatherList, SEXP quiet) {
   #ifdef RSWDEBUG
   if (debug) swprintf(" run SOILWAT2 ...");
   #endif
-	SW_CTL_main(&SoilWatAll, SoilWatOutputPtrs, &PathInfo, &LogInfo);
+	SW_CTL_main(&SoilWatAll, SoilWatOutputPtrs, &LogInfo);
 
    // de-allocate all memory, but let R handle `p_OUT`
   #ifdef RSWDEBUG

--- a/src/SW_R_lib.h
+++ b/src/SW_R_lib.h
@@ -24,6 +24,12 @@ extern SEXP WeatherList;
 extern Bool useFiles;
 extern Bool bWeatherList;
 
+extern SW_ALL SoilWatAll;
+extern SW_OUTPUT_POINTERS SoilWatOutputPtrs[SW_OUTNKEYS];
+extern LOG_INFO LogInfo;
+extern PATH_INFO PathInfo;
+extern Bool EchoInits;
+
 
 /* =================================================== */
 /*             Global Function Declarations            */

--- a/src/rSW_Control.c
+++ b/src/rSW_Control.c
@@ -59,7 +59,7 @@ void rSW_CTL_obtain_inputs(Bool from_files) {
   #endif
 
   if (from_files) {
-    SW_CTL_read_inputs_from_disk();
+    SW_CTL_read_inputs_from_disk(&SoilWatAll, &PathInfo, &LogInfo);
 
   } else { //Use R data to set the data
     #ifdef RSWDEBUG

--- a/src/rSW_Files.c
+++ b/src/rSW_Files.c
@@ -22,9 +22,9 @@
 #include "SOILWAT2/include/myMemory.h"
 #include "SOILWAT2/include/SW_Defines.h"
 
-// externs `*InFiles`, `_ProjDir`, `weather_prefix`, `output_prefix`
 #include "SOILWAT2/include/SW_Files.h"
 #include "rSW_Files.h"
+#include "SW_R_lib.h"
 
 #include <R.h>
 #include <Rinternals.h>
@@ -49,19 +49,19 @@ SEXP onGet_SW_F(void) {
 	PROTECT(swFiles = MAKE_CLASS("swFiles"));
 	PROTECT(SW_F_construct = NEW_OBJECT(swFiles));
 	PROTECT(ProjDir = allocVector(STRSXP, 1));
-	SET_STRING_ELT(ProjDir, 0, mkChar(_ProjDir));
+	SET_STRING_ELT(ProjDir, 0, mkChar(PathInfo._ProjDir));
 
 	PROTECT(FilesIn = allocVector(STRSXP, SW_NFILES));
 	for (i = 0; i < SW_NFILES; i++) {
-		if (InFiles[i] != NULL ) {
-			SET_STRING_ELT(FilesIn, i, mkChar(InFiles[i]));
+		if (PathInfo.InFiles[i] != NULL ) {
+			SET_STRING_ELT(FilesIn, i, mkChar(PathInfo.InFiles[i]));
 		}
 	}
 
 	PROTECT(Rweather_prefix = allocVector(STRSXP, 1));
-	SET_STRING_ELT(Rweather_prefix, 0, mkChar(weather_prefix));
+	SET_STRING_ELT(Rweather_prefix, 0, mkChar(PathInfo.weather_prefix));
 	PROTECT(Routput_prefix = allocVector(STRSXP, 1));
-	SET_STRING_ELT(Routput_prefix, 0, mkChar(output_prefix));
+	SET_STRING_ELT(Routput_prefix, 0, mkChar(PathInfo.output_prefix));
 	// attaching main's elements
 	SET_SLOT(SW_F_construct, install(cSW_F_construct_names[0]), ProjDir);
 	SET_SLOT(SW_F_construct, install(cSW_F_construct_names[1]), FilesIn);
@@ -80,22 +80,22 @@ void onSet_SW_F(SEXP SW_F_construct) {
 	SEXP Routput_prefix;
 
 	PROTECT(ProjDir = GET_SLOT(SW_F_construct, install("ProjDir")));
-	strcpy(_ProjDir, CHAR(STRING_ELT(ProjDir,0)));
+	strcpy(PathInfo._ProjDir, CHAR(STRING_ELT(ProjDir,0)));
 
 	PROTECT(FilesIn = GET_SLOT(SW_F_construct, install("InFiles")));
 	j = LENGTH(FilesIn);
 	for(i=0;i<SW_NFILES;i++)
-		if (!isnull(InFiles[i])) {
-			Mem_Free(InFiles[i]);
+		if (!isnull(PathInfo.InFiles[i])) {
+			Mem_Free(PathInfo.InFiles[i]);
 		}
 	for (i = 0; i < j; i++) {
-		InFiles[i] = Str_Dup(CHAR(STRING_ELT(FilesIn,i)));
+		PathInfo.InFiles[i] = Str_Dup(CHAR(STRING_ELT(FilesIn,i)), &LogInfo);
 	}
 
 	PROTECT(Rweather_prefix = GET_SLOT(SW_F_construct, install("WeatherPrefix")));
-	strcpy(weather_prefix, CHAR(STRING_ELT(Rweather_prefix,0)));
+	strcpy(PathInfo.weather_prefix, CHAR(STRING_ELT(Rweather_prefix,0)));
 
 	PROTECT(Routput_prefix = GET_SLOT(SW_F_construct, install("OutputPrefix")));
-	strcpy(output_prefix, CHAR(STRING_ELT(Routput_prefix,0)));
+	strcpy(PathInfo.output_prefix, CHAR(STRING_ELT(Routput_prefix,0)));
 	UNPROTECT(4);
 }

--- a/src/rSW_Markov.c
+++ b/src/rSW_Markov.c
@@ -27,7 +27,8 @@
 #include "SOILWAT2/include/SW_Weather.h"
 #include "SOILWAT2/include/SW_Markov.h"
 
-#include "rSW_Markov.h" // externs `SW_Markov`
+#include "rSW_Markov.h"
+#include "SW_R_lib.h"
 
 #include <R.h>
 #include <Rinternals.h>
@@ -63,23 +64,23 @@ SEXP onGet_MKV(void) {
 void onSet_MKV(SEXP MKV) {
   SEXP MKV_prob, MKV_conv;
 
-  SW_MKV_construct();
+  SW_MKV_construct(SoilWatAll.Weather.rng_seed, &SoilWatAll.Markov, &LogInfo);
 
   PROTECT(MKV_prob = GET_SLOT(MKV, install(cSW_MKV[0])));
   PROTECT(MKV_conv = GET_SLOT(MKV, install(cSW_MKV[1])));
 
-  if (!onSet_MKV_prob(MKV_prob) && SW_Weather.generateWeatherMethod == 2) {
+  if (!onSet_MKV_prob(MKV_prob) && SoilWatAll.Weather.generateWeatherMethod == 2) {
     LogError(
-      logfp,
+      &LogInfo,
       LOGFATAL,
       "Markov weather generator: "
       "rSOILWAT2 failed to pass `MKV_prob` values to SOILWAT2.\n"
     );
   }
 
-  if (!onSet_MKV_conv(MKV_conv) && SW_Weather.generateWeatherMethod == 2) {
+  if (!onSet_MKV_conv(MKV_conv) && SoilWatAll.Weather.generateWeatherMethod == 2) {
     LogError(
-      logfp,
+      &LogInfo,
       LOGFATAL,
       "Markov weather generator: "
       "rSOILWAT2 failed to pass `MKV_conv` values to SOILWAT2.\n"
@@ -93,7 +94,7 @@ void onSet_MKV(SEXP MKV) {
 SEXP onGet_MKV_prob(void) {
 	int i;
 	const int nitems = 5;
-	SW_MARKOV *v = &SW_Markov;
+	SW_MARKOV *v = &SoilWatAll.Markov;
 	SEXP MKV_prob, MKV_prob_names, MKV_prob_names_y;
 	RealD *p_MKV_prob;
 	char *cMKC_prob[] = { "DOY", "p_wet_wet", "p_wet_dry", "avg_ppt", "std_ppt" };
@@ -124,7 +125,7 @@ SEXP onGet_MKV_prob(void) {
 }
 
 Bool onSet_MKV_prob(SEXP MKV_prob) {
-	SW_MARKOV *v = &SW_Markov;
+	SW_MARKOV *v = &SoilWatAll.Markov;
 	const int nitems = 5;
 	int i;
 	RealD *p_MKV_prob;
@@ -148,7 +149,7 @@ Bool onSet_MKV_prob(SEXP MKV_prob) {
 SEXP onGet_MKV_conv(void) {
 	int i;
 	const int nitems = 11;
-	SW_MARKOV *v = &SW_Markov;
+	SW_MARKOV *v = &SoilWatAll.Markov;
 	SEXP MKV_conv, MKV_conv_names, MKV_conv_names_y;
 	RealD *p_MKV_conv;
 	char *cMKV_conv[] = { "WEEK", "wTmax_C", "wTmin_C", "var_wTmax",
@@ -184,7 +185,7 @@ SEXP onGet_MKV_conv(void) {
 }
 
 Bool onSet_MKV_conv(SEXP MKV_conv) {
-	SW_MARKOV *v = &SW_Markov;
+	SW_MARKOV *v = &SoilWatAll.Markov;
 	const int nitems = 11;
 	int i;
 	RealD *p_MKV_conv;

--- a/src/rSW_Output.c
+++ b/src/rSW_Output.c
@@ -19,18 +19,19 @@
 #include <string.h>
 #include <ctype.h>
 
-#include "SOILWAT2/include/generic.h" // externs `EchoInits`
+#include "SOILWAT2/include/generic.h"
 #include "SOILWAT2/include/filefuncs.h"
 #include "SOILWAT2/include/Times.h"
 #include "SOILWAT2/include/myMemory.h"
 
 #include "SOILWAT2/include/SW_Defines.h"
 #include "SOILWAT2/include/SW_Files.h"
-#include "SOILWAT2/include/SW_Site.h" // externs `SW_Site`
+#include "SOILWAT2/include/SW_Site.h"
 
 #include "SOILWAT2/include/SW_Output.h" // externs many variables
 #include "SOILWAT2/include/SW_Output_outarray.h" // for function `SW_OUT_set_nrow`
 #include "rSW_Output.h"
+#include "SW_R_lib.h"
 
 #include <R.h>
 #include <Rinternals.h>
@@ -67,16 +68,15 @@ void onSet_SW_OUT(SEXP OUT) {
 	#ifdef RSWDEBUG
 	if (debug) swprintf("onSet_SW_OUT: start ...");
 	#endif
-	MyFileName = SW_F_name(eOutput);
+	MyFileName = PathInfo.InFiles[eOutput];
 
 	PROTECT(sep = GET_SLOT(OUT, install("outputSeparator")));
-	_Sep = '\t';/*TODO Make this work.*/
 
 	// TODO: I don't know why `GET_SLOT(OUT, install("timeSteps"))` is suddenly
 	// of type real and not integer any more
 	PROTECT(tp_convert = coerceVector(GET_SLOT(OUT, install("timeSteps")), INTSXP));
 	timePeriods = INTEGER(tp_convert);
-	used_OUTNPERIODS = INTEGER(GET_DIM(GET_SLOT(OUT, install("timeSteps"))))[1]; // number of columns
+	SoilWatAll.GenOutput.used_OUTNPERIODS = INTEGER(GET_DIM(GET_SLOT(OUT, install("timeSteps"))))[1]; // number of columns
 
 	// mykey, myobj and use are currently unused:
 	// mykey = INTEGER(GET_SLOT(OUT, install("mykey")));
@@ -94,25 +94,29 @@ void onSet_SW_OUT(SEXP OUT) {
 			first_orig[k],
 			last_orig[k],
 			msg,
-			sizeof msg
+			sizeof msg,
+			&SoilWatAll.VegProd.use_SWA,
+			SoilWatAll.Site.deepdrain,
+			SoilWatAll.Output,
+			PathInfo.InFiles
 		);
 
 		if (msg_type > 0) {
-			LogError(logfp, msg_type, "%s", msg);
+			LogError(&LogInfo, msg_type, "%s", msg);
 			continue;
 		}
 
-		if (SW_Output[k].use) {
-			SW_Output[k].outfile = Str_Dup(CHAR(STRING_ELT(outfile, k)));
+		if (SoilWatAll.Output[k].use) {
+			SoilWatAll.Output[k].outfile = Str_Dup(CHAR(STRING_ELT(outfile, k)), &LogInfo);
 
 			ForEachOutPeriod(i) {
-				timeSteps[k][i] = timePeriods[k + i * SW_OUTNKEYS];
+				SoilWatAll.GenOutput.timeSteps[k][i] = timePeriods[k + i * SW_OUTNKEYS];
 			}
 		}
 	}
 
 	if (EchoInits)
-		_echo_outputs();
+		_echo_outputs(&SoilWatAll, &LogInfo);
 
 	UNPROTECT(3);
 
@@ -132,6 +136,7 @@ SEXP onGet_SW_OUT(void) {
 	SEXP swOUT, OUT, sep, timePeriods;
 	SEXP mykey, myobj, sumtype, use, first_orig, last_orig, outfile;
 	char *cKEY[] = {"mykey", "myobj", "sumtype", "use", "first_orig", "last_orig", "outfile"};
+	char _Sep = '\t';
   #ifdef RSWDEBUG
   int debug = 0;
   #endif
@@ -163,20 +168,20 @@ SEXP onGet_SW_OUT(void) {
 
 	ForEachOutKey(k)
 	{
-		INTEGER(mykey)[k] = SW_Output[k].mykey;
-		INTEGER(myobj)[k] = SW_Output[k].myobj;
-		INTEGER(sumtype)[k] = SW_Output[k].sumtype;
-		LOGICAL(use)[k] = SW_Output[k].use;
-		INTEGER(first_orig)[k] = SW_Output[k].first_orig;
-		INTEGER(last_orig)[k] = SW_Output[k].last_orig;
+		INTEGER(mykey)[k] = SoilWatAll.Output[k].mykey;
+		INTEGER(myobj)[k] = SoilWatAll.Output[k].myobj;
+		INTEGER(sumtype)[k] = SoilWatAll.Output[k].sumtype;
+		LOGICAL(use)[k] = SoilWatAll.Output[k].use;
+		INTEGER(first_orig)[k] = SoilWatAll.Output[k].first_orig;
+		INTEGER(last_orig)[k] = SoilWatAll.Output[k].last_orig;
 
-		if (SW_Output[k].use)
+		if (SoilWatAll.Output[k].use)
 		{
-			for (i = 0; i < used_OUTNPERIODS; i++) {
-				vtimePeriods[k + i * SW_OUTNKEYS] = timeSteps[k][i];
+			for (i = 0; i < SoilWatAll.GenOutput.used_OUTNPERIODS; i++) {
+				vtimePeriods[k + i * SW_OUTNKEYS] = SoilWatAll.GenOutput.timeSteps[k][i];
 			}
 
-			SET_STRING_ELT(outfile, k, mkChar(SW_Output[k].outfile));
+			SET_STRING_ELT(outfile, k, mkChar(SoilWatAll.Output[k].outfile));
 		} else {
 			SET_STRING_ELT(outfile, k, mkChar(""));
 		}
@@ -218,12 +223,14 @@ void setGlobalrSOILWAT2_OutputVariables(SEXP outputData) {
 
 	// Get the pointers to the output arrays that were pre-allocated by `onGetOutput`
 	ForEachOutKey(k) {
-		for (i = 0; i < used_OUTNPERIODS; i++) {
+		for (i = 0; i < SoilWatAll.GenOutput.used_OUTNPERIODS; i++) {
 
-			if (SW_Output[k].use && timeSteps[k][i] != eSW_NoTime)
+			if (SoilWatAll.Output[k].use &&
+						SoilWatAll.GenOutput.timeSteps[k][i] != eSW_NoTime)
 			{
-				p_OUT[k][timeSteps[k][i]] = REAL(GET_SLOT(GET_SLOT(outputData,
-					install(key2str[k])), install(pd2longstr[timeSteps[k][i]])));
+				SoilWatAll.GenOutput.p_OUT[k][SoilWatAll.GenOutput.timeSteps[k][i]] =
+					REAL(GET_SLOT(GET_SLOT(outputData, install(key2str[k])),
+					install(pd2longstr[SoilWatAll.GenOutput.timeSteps[k][i]])));
 			}
 		}
 	}
@@ -242,6 +249,8 @@ SEXP onGetOutput(SEXP inputData) {
 
 	char *cSWoutput_Names[] = {"dy_nrow", "wk_nrow", "mo_nrow", "yr_nrow"};
 
+	SW_GEN_OUT *GenOut = &SoilWatAll.GenOutput;
+
   #ifdef RSWDEBUG
   int debug = 0;
   #endif
@@ -253,7 +262,7 @@ SEXP onGetOutput(SEXP inputData) {
 	PROTECT(swOutput = MAKE_CLASS("swOutput"));
 	PROTECT(swOutput_Object = NEW_OBJECT(swOutput));
 
-	if (used_OUTNPERIODS <= 0) {
+	if (GenOut->used_OUTNPERIODS <= 0) {
 		UNPROTECT(2);
 		return(swOutput_Object);
 	}
@@ -262,16 +271,17 @@ SEXP onGetOutput(SEXP inputData) {
 	use = LOGICAL(GET_SLOT(GET_SLOT(inputData, install("output")), install("use")));
 
 	// Determine which output periods are turned on for at least one output key
-	find_OutPeriods_inUse();
+	find_OutPeriods_inUse(&SoilWatAll.GenOutput, SoilWatAll.Output);
 
 	// Determine number of used years/months/weeks/days in simulation period
-	SW_OUT_set_nrow();
+	SW_OUT_set_nrow(&SoilWatAll.Model, GenOut->use_OutPeriod,
+					GenOut->nrow_OUT);
 
 	ForEachOutPeriod(pd) {
 		SET_SLOT(
 			swOutput_Object,
 			install(cSWoutput_Names[pd]),
-			ScalarInteger(nrow_OUT[pd]));
+			ScalarInteger(GenOut->nrow_OUT[pd]));
 	}
 
 	// KEYS
@@ -283,38 +293,41 @@ SEXP onGetOutput(SEXP inputData) {
 	ForEachOutKey(k) {
 		if (use[k]) {
 			#ifdef RSWDEBUG
-			if (debug) swprintf("%s (ncol = %d):", key2str[k], ncol_OUT[k]);
+			if (debug) swprintf("%s (ncol = %d):", key2str[k], GenOut->ncol_OUT[k]);
 			#endif
 
 			PROTECT(stemp_KEY = NEW_OBJECT(swOutput_KEY));
 
-			SET_SLOT(stemp_KEY, install("Title"), mkString(Str_Dup(CHAR(STRING_ELT(outfile, k)))));
-			SET_SLOT(stemp_KEY, install("Columns"), ScalarInteger(ncol_OUT[k]));
+			SET_SLOT(stemp_KEY, install("Title"), mkString(Str_Dup(CHAR(STRING_ELT(outfile, k)), &LogInfo)));
+			SET_SLOT(stemp_KEY, install("Columns"), ScalarInteger(GenOut->ncol_OUT[k]));
 
-			PROTECT(rTimeStep = NEW_INTEGER(used_OUTNPERIODS));
-			for (i = 0; i < used_OUTNPERIODS; i++) {
-				INTEGER(rTimeStep)[i] = timeSteps[k][i];
+			PROTECT(rTimeStep = NEW_INTEGER(GenOut->used_OUTNPERIODS));
+			for (i = 0; i < GenOut->used_OUTNPERIODS; i++) {
+				INTEGER(rTimeStep)[i] = GenOut->timeSteps[k][i];
 			}
 			SET_SLOT(stemp_KEY, install("TimeStep"), rTimeStep);
 
-			for (i = 0; i < used_OUTNPERIODS; i++) {
-				if (timeSteps[k][i] == eSW_NoTime) {
+			for (i = 0; i < GenOut->used_OUTNPERIODS; i++) {
+				if (GenOut->timeSteps[k][i] == eSW_NoTime) {
 					continue;
 				}
 
 				#ifdef RSWDEBUG
 				if (debug) swprintf(" %s (n=%ld = %ld x (%d + %d) alloc'ed) /",
-					pd2longstr[timeSteps[k][i]], nrow_OUT[timeSteps[k][i]] *
-					(ncol_OUT[k] + ncol_TimeOUT[timeSteps[k][i]]),
-					nrow_OUT[timeSteps[k][i]], ncol_OUT[k], ncol_TimeOUT[timeSteps[k][i]]);
+					pd2longstr[GenOut->timeSteps[k][i]],
+					GenOut->nrow_OUT[GenOut->timeSteps[k][i]] *
+					(GenOut->ncol_OUT[k] + ncol_TimeOUT[GenOut->timeSteps[k][i]]),
+					GenOut->nrow_OUT[GenOut->timeSteps[k][i]],
+					GenOut->ncol_OUT[k], ncol_TimeOUT[GenOut->timeSteps[k][i]]);
 				#endif
 
-				h = ncol_TimeOUT[timeSteps[k][i]];
+				h = ncol_TimeOUT[GenOut->timeSteps[k][i]];
 
-				PROTECT(xKEY = allocMatrix(REALSXP, nrow_OUT[timeSteps[k][i]],
-					ncol_OUT[k] + h)); // future output data matrix
+				PROTECT(xKEY = allocMatrix(REALSXP, GenOut->nrow_OUT[GenOut->timeSteps[k][i]],
+					GenOut->ncol_OUT[k] + h)); // future output data matrix
 
-				for (l = 0; l < nrow_OUT[timeSteps[k][i]] * (ncol_OUT[k] + h); l++) {
+				for (l = 0; l < GenOut->nrow_OUT[GenOut->timeSteps[k][i]] *
+												(GenOut->ncol_OUT[k] + h); l++) {
 					// Initialize to 0:
 					// allocMatrix does not initialize and memset appears to not work on
 					// `allocMatrix` objects
@@ -322,18 +335,19 @@ SEXP onGetOutput(SEXP inputData) {
 				}
 
 				PROTECT(xKEY_names = allocVector(VECSXP, 2)); // list of dimnames
-				PROTECT(xKEY_cnames = allocVector(STRSXP, ncol_OUT[k] + h)); // vector of column names
+				PROTECT(xKEY_cnames = allocVector(STRSXP, GenOut->ncol_OUT[k] + h)); // vector of column names
 				SET_STRING_ELT(xKEY_cnames, 0, mkChar("Year"));
 				if (h == 2) {
-					SET_STRING_ELT(xKEY_cnames, 1, mkChar(pd2longstr[timeSteps[k][i]]));
+					SET_STRING_ELT(xKEY_cnames, 1, mkChar(pd2longstr[GenOut->timeSteps[k][i]]));
 				}
-				for (l = 0; l < ncol_OUT[k]; l++) {
-					SET_STRING_ELT(xKEY_cnames, l + h, mkChar(colnames_OUT[k][l]));
+				for (l = 0; l < GenOut->ncol_OUT[k]; l++) {
+					SET_STRING_ELT(xKEY_cnames, l + h,
+							mkChar(GenOut->colnames_OUT[k][l]));
 				}
 				SET_VECTOR_ELT(xKEY_names, 1, xKEY_cnames);
 				dimnamesgets(xKEY, xKEY_names);
 
-				SET_SLOT(stemp_KEY, install(pd2longstr[timeSteps[k][i]]), xKEY);
+				SET_SLOT(stemp_KEY, install(pd2longstr[GenOut->timeSteps[k][i]]), xKEY);
 				UNPROTECT(3);
 			}
 

--- a/src/rSW_Site.c
+++ b/src/rSW_Site.c
@@ -19,7 +19,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "SOILWAT2/include/generic.h" // externs `EchoInits`
+#include "SOILWAT2/include/generic.h"
 #include "SOILWAT2/include/filefuncs.h"
 #include "SOILWAT2/include/Times.h"
 #include "SOILWAT2/include/myMemory.h"
@@ -28,9 +28,9 @@
 #include "SOILWAT2/include/SW_Files.h"
 #include "SOILWAT2/include/SW_SoilWater.h"
 
-// externs `SW_Site`, `_TranspRgnBounds`, _SWCInitVal, _SWCWetVal, _SWCMinVal
 #include "SOILWAT2/include/SW_Site.h"
 #include "rSW_Site.h"
+#include "SW_R_lib.h"
 
 #include <R.h>
 #include <Rinternals.h>
@@ -73,25 +73,25 @@ static char *cSWRCp[] = {
 /* Copy soil properties into "Layers" matrix */
 static SEXP onGet_SW_LYR(void) {
 	int i, dmax = 0;
-	SW_SITE *v = &SW_Site;
+	SW_SITE *v = &SoilWatAll.Site;
 	SEXP Layers, Layers_names, Layers_names_y;
 	RealD *p_Layers;
 
 	PROTECT(Layers = allocMatrix(REALSXP, v->n_layers, 12));
 	p_Layers = REAL(Layers);
 	for (i = 0; i < (v->n_layers); i++) {
-		p_Layers[i + (v->n_layers) * 0] = dmax = v->lyr[i]->width + dmax;
-		p_Layers[i + (v->n_layers) * 1] = v->lyr[i]->soilDensityInput;
-		p_Layers[i + (v->n_layers) * 2] = v->lyr[i]->fractionVolBulk_gravel;
-		p_Layers[i + (v->n_layers) * 3] = v->lyr[i]->evap_coeff;
-		p_Layers[i + (v->n_layers) * 4] = v->lyr[i]->transp_coeff[SW_GRASS];
-		p_Layers[i + (v->n_layers) * 5] = v->lyr[i]->transp_coeff[SW_SHRUB];
-		p_Layers[i + (v->n_layers) * 6] = v->lyr[i]->transp_coeff[SW_TREES];
-		p_Layers[i + (v->n_layers) * 7] = v->lyr[i]->transp_coeff[SW_FORBS];
-		p_Layers[i + (v->n_layers) * 8] = v->lyr[i]->fractionWeightMatric_sand;
-		p_Layers[i + (v->n_layers) * 9] = v->lyr[i]->fractionWeightMatric_clay;
-		p_Layers[i + (v->n_layers) * 10] = v->lyr[i]->impermeability;
-		p_Layers[i + (v->n_layers) * 11] = v->lyr[i]->avgLyrTemp;
+		p_Layers[i + (v->n_layers) * 0] = dmax = v->width[i] + dmax;
+		p_Layers[i + (v->n_layers) * 1] = v->soilDensityInput[i];
+		p_Layers[i + (v->n_layers) * 2] = v->fractionVolBulk_gravel[i];
+		p_Layers[i + (v->n_layers) * 3] = v->evap_coeff[i];
+		p_Layers[i + (v->n_layers) * 4] = v->transp_coeff[SW_GRASS][i];
+		p_Layers[i + (v->n_layers) * 5] = v->transp_coeff[SW_SHRUB][i];
+		p_Layers[i + (v->n_layers) * 6] = v->transp_coeff[SW_TREES][i];
+		p_Layers[i + (v->n_layers) * 7] = v->transp_coeff[SW_FORBS][i];
+		p_Layers[i + (v->n_layers) * 8] = v->fractionWeightMatric_sand[i];
+		p_Layers[i + (v->n_layers) * 9] = v->fractionWeightMatric_clay[i];
+		p_Layers[i + (v->n_layers) * 10] = v->impermeability[i];
+		p_Layers[i + (v->n_layers) * 11] = v->avgLyrTempInit[i];
 	}
 
 	PROTECT(Layers_names = allocVector(VECSXP, 2));
@@ -111,14 +111,14 @@ static SEXP onGet_SW_LYR(void) {
 */
 static void onSet_SW_LYR(SEXP SW_LYR) {
 
-	SW_SITE *v = &SW_Site;
+	SW_SITE *v = &SoilWatAll.Site;
 	LyrIndex lyrno;
 	int i, j, k, columns;
 	RealF dmin = 0.0, dmax, evco, trco_veg[NVEGTYPES], psand, pclay, soildensity, imperm, soiltemp, f_gravel;
 	RealD *p_Layers;
 
 	/* note that Files.read() must be called prior to this. */
-	MyFileName = SW_F_name(eLayers);
+	MyFileName = PathInfo.InFiles[eLayers];
 
 	j = nrows(SW_LYR);
 	p_Layers = REAL(SW_LYR);
@@ -128,7 +128,7 @@ static void onSet_SW_LYR(SEXP SW_LYR) {
 	/* Adjust number if new variables are added */
 	if (columns != 12) {
 		LogError(
-			logfp,
+			&LogInfo,
 			LOGFATAL,
 			"%s : Too few columns in layers specified (%d).\n",
 			MyFileName, columns
@@ -136,7 +136,7 @@ static void onSet_SW_LYR(SEXP SW_LYR) {
 	}
 
 	for (i = 0; i < j; i++) {
-		lyrno = _newlayer();
+		lyrno = SoilWatAll.Site.n_layers++;
 
 		dmax = p_Layers[i + j * 0];
 		soildensity = p_Layers[i + j * 1];
@@ -151,22 +151,22 @@ static void onSet_SW_LYR(SEXP SW_LYR) {
 		imperm = p_Layers[i + j * 10];
 		soiltemp = p_Layers[i + j * 11];
 
-		v->lyr[lyrno]->width = dmax - dmin;
+		v->width[lyrno] = dmax - dmin;
 		dmin = dmax;
-		v->lyr[lyrno]->soilDensityInput = soildensity;
-		v->lyr[lyrno]->fractionVolBulk_gravel = f_gravel;
-		v->lyr[lyrno]->evap_coeff = evco;
+		v->soilDensityInput[lyrno] = soildensity;
+		v->fractionVolBulk_gravel[lyrno] = f_gravel;
+		v->evap_coeff[lyrno] = evco;
 		ForEachVegType(k) {
-			v->lyr[lyrno]->transp_coeff[k] = trco_veg[k];
+			v->transp_coeff[k][lyrno] = trco_veg[k];
 		}
-		v->lyr[lyrno]->fractionWeightMatric_sand = psand;
-		v->lyr[lyrno]->fractionWeightMatric_clay = pclay;
-		v->lyr[lyrno]->impermeability = imperm;
-		v->lyr[lyrno]->avgLyrTemp = soiltemp;
+		v->fractionWeightMatric_sand[lyrno] = psand;
+		v->fractionWeightMatric_clay[lyrno] = pclay;
+		v->impermeability[lyrno] = imperm;
+		v->avgLyrTempInit[lyrno] = soiltemp;
 
 		if (lyrno >= MAX_LAYERS) {
 			LogError(
-				logfp,
+				&LogInfo,
 				LOGFATAL,
 				"%s : Too many layers specified (%d).\n"
 				"Maximum number of layers is %d\n",
@@ -180,7 +180,7 @@ static void onSet_SW_LYR(SEXP SW_LYR) {
 /* Copy SWRC parameters into "SWRCp" matrix */
 static SEXP onGet_SW_SWRCp(void) {
 	int i, k;
-	SW_SITE *v = &SW_Site;
+	SW_SITE *v = &SoilWatAll.Site;
 	SEXP SWRCp, SWRCp_names, SWRCp_names_y;
 	RealD *p_SWRCp;
 
@@ -188,7 +188,7 @@ static SEXP onGet_SW_SWRCp(void) {
 	p_SWRCp = REAL(SWRCp);
 	for (i = 0; i < (v->n_layers); i++) {
 		for (k = 0; k < SWRC_PARAM_NMAX; k++) {
-			p_SWRCp[i + (v->n_layers) * k] = v->lyr[i]->swrcp[k];
+			p_SWRCp[i + (v->n_layers) * k] = v->swrcp[i][k];
 		}
 	}
 
@@ -207,17 +207,17 @@ static SEXP onGet_SW_SWRCp(void) {
 /* Function `onSet_SW_SWRCp()` corresponds to SOILWAT2's `SW_SWRC_read()` */
 static void onSet_SW_SWRCp(SEXP SW_SWRCp) {
 
-	SW_SITE *v = &SW_Site;
+	SW_SITE *v = &SoilWatAll.Site;
 	int i, k;
 	RealD *p_SWRCp;
 
 	/* note that Files.read() must be called prior to this. */
-	MyFileName = SW_F_name(eSWRCp);
+	MyFileName = PathInfo.InFiles[eSWRCp];
 
 	/* Check that we have n = `SWRC_PARAM_NMAX` values per layer */
 	if (ncols(SW_SWRCp) != SWRC_PARAM_NMAX) {
 		LogError(
-			logfp,
+			&LogInfo,
 			LOGFATAL,
 			"%s : Bad number of SWRC parameters %d -- must be %d.\n",
 			MyFileName, ncols(SW_SWRCp), SWRC_PARAM_NMAX
@@ -225,13 +225,13 @@ static void onSet_SW_SWRCp(SEXP SW_SWRCp) {
 	}
 
 	/* Check that we have `SW_Site.n_layers` */
-	if (nrows(SW_SWRCp) != SW_Site.n_layers) {
+	if (nrows(SW_SWRCp) != SoilWatAll.Site.n_layers) {
 		LogError(
-			logfp,
+			&LogInfo,
 			LOGFATAL,
 			"%s : Number of layers with SWRC parameters (%d) "
 			"must match number of soil layers (%d)\n",
-			MyFileName, nrows(SW_SWRCp), SW_Site.n_layers
+			MyFileName, nrows(SW_SWRCp), SoilWatAll.Site.n_layers
 		);
 	}
 
@@ -240,7 +240,7 @@ static void onSet_SW_SWRCp(SEXP SW_SWRCp) {
 
 	for (i = 0; i < (v->n_layers); i++) {
 		for (k = 0; k < SWRC_PARAM_NMAX; k++) {
-			v->lyr[i]->swrcp[k] = p_SWRCp[i + (v->n_layers) * k];
+			v->swrcp[i][k] = p_SWRCp[i + (v->n_layers) * k];
 		}
 	}
 }
@@ -280,7 +280,7 @@ void onSet_SW_SOILS(SEXP SW_SOILS) {
 
 SEXP onGet_SW_SIT(void) {
 	int i;
-	SW_SITE *v = &SW_Site;
+	SW_SITE *v = &SoilWatAll.Site;
 
 	SEXP swSite;
 	SEXP SW_SIT;
@@ -327,15 +327,15 @@ SEXP onGet_SW_SIT(void) {
 	char *cTranspirationRegions[] = { "ndx", "layer" };
 	int *p_transp; // ideally `LyrIndex` so that same type as `_TranspRgnBounds`, but R API INTEGER() is signed
 
-	MyFileName = SW_F_name(eSite);
+	MyFileName = PathInfo.InFiles[eSite];
 
 	PROTECT(swSite = MAKE_CLASS("swSite"));
 	PROTECT(SW_SIT = NEW_OBJECT(swSite));
 
 	PROTECT(SWClimits = allocVector(REALSXP, 3));
-	REAL(SWClimits)[0] = _SWCMinVal;
-	REAL(SWClimits)[1] = _SWCInitVal;
-	REAL(SWClimits)[2] = _SWCWetVal;
+	REAL(SWClimits)[0] = v->_SWCMinVal;
+	REAL(SWClimits)[1] = v->_SWCInitVal;
+	REAL(SWClimits)[2] = v->_SWCWetVal;
 	PROTECT(SWClimits_names = allocVector(STRSXP, 3));
 	for (i = 0; i < 3; i++)
 		SET_STRING_ELT(SWClimits_names, i, mkChar(cSWClimits[i]));
@@ -432,7 +432,7 @@ SEXP onGet_SW_SIT(void) {
 	p_transp = INTEGER(TranspirationRegions);
 	for (i = 0; i < (v->n_transp_rgn); i++) {
 		p_transp[i + (v->n_transp_rgn) * 0] = (i + 1);
-		p_transp[i + (v->n_transp_rgn) * 1] = (_TranspRgnBounds[i]+1);
+		p_transp[i + (v->n_transp_rgn) * 1] = (v->_TranspRgnBounds[i]+1);
 	}
 	PROTECT(TranspirationRegions_names = allocVector(VECSXP,2));
 	PROTECT(TranspirationRegions_names_y = allocVector(STRSXP,2));
@@ -478,7 +478,7 @@ SEXP onGet_SW_SIT(void) {
 
 void onSet_SW_SIT(SEXP SW_SIT) {
 	int i;
-	SW_SITE *v = &SW_Site;
+	SW_SITE *v = &SoilWatAll.Site;
 
 	SEXP SWClimits;
 	SEXP ModelFlags;
@@ -500,7 +500,7 @@ void onSet_SW_SIT(SEXP SW_SIT) {
   int debug = 0;
   #endif
 
-	MyFileName = SW_F_name(eSite);
+	MyFileName = PathInfo.InFiles[eSite];
 
 	LyrIndex r; /* transp region definition number */
 	Bool too_many_regions = FALSE;
@@ -510,9 +510,9 @@ void onSet_SW_SIT(SEXP SW_SIT) {
 	#endif
 
 	PROTECT(SWClimits = GET_SLOT(SW_SIT, install("SWClimits")));
-	_SWCMinVal = REAL(SWClimits)[0];
-	_SWCInitVal = REAL(SWClimits)[1];
-	_SWCWetVal = REAL(SWClimits)[2];
+	v->_SWCMinVal = REAL(SWClimits)[0];
+	v->_SWCInitVal = REAL(SWClimits)[1];
+	v->_SWCWetVal = REAL(SWClimits)[2];
 	#ifdef RSWDEBUG
 	if (debug) swprintf(" > 'SWClimits'");
 	#endif
@@ -608,7 +608,7 @@ void onSet_SW_SIT(SEXP SW_SIT) {
 
 	PROTECT(swrc_flags = GET_SLOT(SW_SIT, install("swrc_flags")));
 	strcpy(v->site_swrc_name, CHAR(STRING_ELT(swrc_flags, 0)));
-	v->site_swrc_type = encode_str2swrc(v->site_swrc_name);
+	v->site_swrc_type = encode_str2swrc(v->site_swrc_name, &LogInfo);
 	strcpy(v->site_ptf_name, CHAR(STRING_ELT(swrc_flags, 1)));
 	v->site_ptf_type = encode_str2ptf(v->site_ptf_name);
 	PROTECT(has_swrcp = GET_SLOT(SW_SIT, install("has_swrcp")));
@@ -626,11 +626,11 @@ void onSet_SW_SIT(SEXP SW_SIT) {
 		too_many_regions = TRUE;
 	} else {
 		for (i = 0; i < v->n_transp_rgn; i++) {
-			_TranspRgnBounds[p_transp[i + v->n_transp_rgn * 0] - 1] = p_transp[i + v->n_transp_rgn * 1] - 1;
+			v->_TranspRgnBounds[p_transp[i + v->n_transp_rgn * 0] - 1] = p_transp[i + v->n_transp_rgn * 1] - 1;
 		}
 	}
 	if (too_many_regions) {
-		LogError(logfp, LOGFATAL, "siteparam.in : Number of transpiration regions"
+		LogError(&LogInfo, LOGFATAL, "siteparam.in : Number of transpiration regions"
 				" exceeds maximum allowed (%d > %d)\n", v->n_transp_rgn, MAX_TRANSP_REGIONS);
 	}
 	#ifdef RSWDEBUG
@@ -639,8 +639,8 @@ void onSet_SW_SIT(SEXP SW_SIT) {
 
 	/* check for any discontinuities (reversals) in the transpiration regions */
 	for (r = 1; r < v->n_transp_rgn; r++) {
-		if (_TranspRgnBounds[r - 1] >= _TranspRgnBounds[r]) {
-			LogError(logfp, LOGFATAL, "siteparam.in : Discontinuity/reversal in transpiration regions.\n");
+		if (v->_TranspRgnBounds[r - 1] >= v->_TranspRgnBounds[r]) {
+			LogError(&LogInfo, LOGFATAL, "siteparam.in : Discontinuity/reversal in transpiration regions.\n");
 		}
 	}
 

--- a/src/rSW_Sky.c
+++ b/src/rSW_Sky.c
@@ -22,9 +22,10 @@
 #include "SOILWAT2/include/SW_Defines.h"
 #include "SOILWAT2/include/SW_Files.h"
 
-#include "SOILWAT2/include/SW_Weather.h" // externs `SW_Weather`
-#include "SOILWAT2/include/SW_Sky.h" // externs `SW_Sky`
+#include "SOILWAT2/include/SW_Weather.h"
+#include "SOILWAT2/include/SW_Sky.h"
 #include "rSW_Sky.h"
+#include "SW_R_lib.h"
 
 #include <R.h>
 #include <Rinternals.h>
@@ -44,7 +45,7 @@ static char *MyFileName;
 SEXP onGet_SW_SKY(void) {
 	int i;
 
-	SW_SKY *v = &SW_Sky;
+	SW_SKY *v = &SoilWatAll.Sky;
 	SEXP swCloud,SW_SKY;
 	SEXP Cloud;
 	SEXP Cloud_names, Cloud_names_x, Cloud_names_y;
@@ -88,12 +89,12 @@ SEXP onGet_SW_SKY(void) {
 
 void onSet_SW_SKY(SEXP sxp_SW_SKY) {
 	int i, k = 5;
-	SW_SKY *v = &SW_Sky;
+	SW_SKY *v = &SoilWatAll.Sky;
 	RealD *p_Cloud;
 	PROTECT(sxp_SW_SKY);
 	p_Cloud = REAL(GET_SLOT(sxp_SW_SKY, install("Cloud")));
 
-	MyFileName = SW_F_name(eSky);
+	MyFileName = PathInfo.InFiles[eSky];
 
 	for (i = 0; i < 12; i++) { //i=columns
 		v->cloudcov[i] = p_Cloud[0 + k * i];


### PR DESCRIPTION
Accommodate SOILWAT2 v7.1.0 developments (DrylandEcology/SOILWAT2#351)

- Updating rSOILWAT2 to be compatible with SOILWAT2 v7.1.0 (thread-safety and reentrancy) will not affect the user interface and is expected to produce identical simulation output
    - -> for rSOILWAT2, this is a patch and not a minor version increase

- previously, this was targeted for v6.0.1 (PR #235)